### PR TITLE
Correct architectures value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=E-Ink displays made by heltec
 paragraph=See more on http://heltec.cn
 category=Device Control
 url=https://github.com/HelTecAutomation/ESP32_LoRaWAN
-architectures=AVR
+architectures=avr


### PR DESCRIPTION
The previous `architectures` value caused the Arduino IDE to display a warning when the library is compiled:
```
WARNING: library e-ink claims to run on (AVR) architecture(s) and may be incompatible with your current board which runs on (avr) architecture(s).
```
The previous architectures value caused the library's examples to be placed under the **File > Examples > INCOMPATIBLE** menu.